### PR TITLE
Allow to pass a full syntax path

### DIFF
--- a/SublimeHelper.py
+++ b/SublimeHelper.py
@@ -213,7 +213,8 @@ class OutputTarget():
                 resources = sublime.find_resources(syntax)
 
                 if not resources:
-                    print('Ressource not found:', syntax)
+                    print('No ressource found matching "%s". Using it as full syntax path.' % syntax)
+                    self.console.set_syntax_file(syntax)
                 else:
                     self.console.set_syntax_file(resources[0])
 

--- a/SublimeHelper.py
+++ b/SublimeHelper.py
@@ -207,8 +207,15 @@ class OutputTarget():
             # Set the syntax for the output:
             #
             if syntax is not None:
-                resources = sublime.find_resources(syntax + '.tmLanguage')
-                self.console.set_syntax_file(resources[0])
+                if not (syntax.endswith('.tmLanguage') or
+                    syntax.endswith('.sublime-syntax')):
+                    syntax += '.tmLanguage'
+                resources = sublime.find_resources(syntax)
+
+                if not resources:
+                    print('Ressource not found:', syntax)
+                else:
+                    self.console.set_syntax_file(resources[0])
 
             # Set a flag on the view that we can use in key bindings:
             #


### PR DESCRIPTION
This changes the way the syntax is set.

It shouldn't impact any user with a working configuration.

As ST now has two formats for syntax files, we want the user to be able to use new syntax format.
Therefore if the "syntax" already contains the extension I don't modify it, else I add ".tmLanguage" like before.

Also if you use a custom "java.sublime-syntax", ShellCommand was always using the default one.
Now if the user uses the full path "Packages/User/java.sublime-syntax", it will be loaded (instead of failing).