### PR TITLE
fix: [#80] setting panel option still results in output to window

### DIFF
--- a/ShellCommand.py
+++ b/ShellCommand.py
@@ -80,8 +80,8 @@ class ShellCommandCommand(SH.TextCommand):
             if prompt is None:
                 prompt = self.default_prompt
             initial = history.last() or ''
-            panel = window.show_input_panel(prompt, initial, _C1, None, None)
-            panel.settings().set("shell_command_panel", True)
+            input_panel = window.show_input_panel(prompt, initial, _C1, None, None)
+            input_panel.settings().set("shell_command_panel", True)
         else:
             # A command can contain variables for substitution. The actual
             # substitution takes place in the module VariableSubstitution,


### PR DESCRIPTION
Fixes #80

I ran into this same issue, the problem was the `panel` boolean would get overwritten with the input panel when asking for user input. A later check if `panel is True` would therefore always fail. 